### PR TITLE
Make workflows easier to reuse

### DIFF
--- a/.github/workflows/uk.yml
+++ b/.github/workflows/uk.yml
@@ -6,8 +6,12 @@ on:
     - cron:  '*/15 * * * *'
 
 jobs:
-  build:
+  bot:
     runs-on: ubuntu-latest
+    env:
+      DATA_URL: 'https://coronavirus.data.gov.uk/api/v1/data?filters=areaName=United%2520Kingdom;areaType=overview&structure=%7B%22areaType%22:%22areaType%22,%22areaName%22:%22areaName%22,%22areaCode%22:%22areaCode%22,%22date%22:%22date%22,%22cumVaccinationFirstDoseUptakeByPublishDatePercentage%22:%22cumVaccinationFirstDoseUptakeByPublishDatePercentage%22,%22cumVaccinationSecondDoseUptakeByPublishDatePercentage%22:%22cumVaccinationSecondDoseUptakeByPublishDatePercentage%22%7D&format=json'
+      TWITTER_SCREEN_NAME: 'fullyjabbedUK'
+      JQ_FILTERS: '.data[0] | .cumVaccinationSecondDoseUptakeByPublishDatePercentage'
 
     steps:
       - uses: actions/checkout@v2
@@ -21,8 +25,7 @@ jobs:
       - name: Fetch current vaccination uptake
         run: |
           FILE=./data/uptake.json
-          url="https://coronavirus.data.gov.uk/api/v1/data?filters=areaName=United%2520Kingdom;areaType=overview&structure=%7B%22areaType%22:%22areaType%22,%22areaName%22:%22areaName%22,%22areaCode%22:%22areaCode%22,%22date%22:%22date%22,%22cumVaccinationFirstDoseUptakeByPublishDatePercentage%22:%22cumVaccinationFirstDoseUptakeByPublishDatePercentage%22,%22cumVaccinationSecondDoseUptakeByPublishDatePercentage%22:%22cumVaccinationSecondDoseUptakeByPublishDatePercentage%22%7D&format=json"
-          response=$(curl -f "$url" --compressed)
+          response=$(curl -f "${{ env.DATA_URL }}" --compressed)
           status=$?
           if [ $status -eq 0 ]; then
               echo $response > $FILE
@@ -33,13 +36,13 @@ jobs:
           fi
       - name: Get latest uptake percentage
         id: uptake
-        run: echo ::set-output name=second::$(cat data/uptake.json | jq '.data[0] | .cumVaccinationSecondDoseUptakeByPublishDatePercentage')
+        run: echo ::set-output name=fully::$(cat data/uptake.json | jq '${{ env.JQ_FILTERS }}' )
       - name: Format tweet
         id: tweet
-        run: echo ::set-output name=formatted::$(bundle exec ruby lib/format_tweet.rb '${{ steps.uptake.outputs.second }}')
+        run: echo ::set-output name=formatted::$(bundle exec ruby lib/format_tweet.rb '${{ steps.uptake.outputs.fully }}')
       - name: Fetch last tweet
         id: last-tweet
-        run: echo ::set-output name=text::$(bundle exec ruby lib/fetch_last_tweet.rb fullyjabbedUK)
+        run: echo ::set-output name=text::$(bundle exec ruby lib/fetch_last_tweet.rb ${{ env.TWITTER_SCREEN_NAME }})
         env:
              API_KEY: ${{ secrets.API_KEY }}
              API_KEY_SECRET: ${{ secrets.API_KEY_SECRET }}
@@ -47,7 +50,7 @@ jobs:
              ACCESS_TOKEN_SECRET: ${{ secrets.ACCESS_TOKEN_SECRET_UK }}
       - name: Debug output
         run: |
-          echo ${{ steps.uptake.outputs.second }}
+          echo ${{ steps.uptake.outputs.fully }}
           echo ${{ steps.tweet.outputs.formatted }}
           echo ${{ steps.last-tweet.outputs.text }}
       - name: Tweet current uptake

--- a/.github/workflows/world.yml
+++ b/.github/workflows/world.yml
@@ -6,8 +6,12 @@ on:
     - cron:  '*/15 * * * *'
 
 jobs:
-  build:
+  bot:
     runs-on: ubuntu-latest
+    env:
+      DATA_URL: 'https://raw.githubusercontent.com/owid/covid-19-data/master/public/data/vaccinations/vaccinations.json'
+      TWITTER_SCREEN_NAME: 'fullyjabbed'
+      JQ_FILTERS: '.[] | select(.iso_code == "OWID_WRL") | .data[-1] | .people_fully_vaccinated_per_hundred'
 
     steps:
       - uses: actions/checkout@v2
@@ -20,9 +24,8 @@ jobs:
         run: sudo apt-get install jq
       - name: Fetch current vaccination uptake
         run: |
-          FILE=./data/world_uptake.json
-          url="https://raw.githubusercontent.com/owid/covid-19-data/master/public/data/vaccinations/vaccinations.json"
-          response=$(curl -f "$url" --compressed)
+          FILE=./data/uptake.json
+          response=$(curl -f "${{ env.DATA_URL }}" --compressed)
           status=$?
           if [ $status -eq 0 ]; then
               echo $response > $FILE
@@ -33,13 +36,13 @@ jobs:
           fi
       - name: Get latest uptake percentage
         id: uptake
-        run: echo ::set-output name=world-fully::$(cat data/world_uptake.json | jq '.[] | select(.iso_code == "OWID_WRL") | .data[-1] | .people_fully_vaccinated_per_hundred')
+        run: echo ::set-output name=fully::$(cat data/uptake.json | jq '${{ env.JQ_FILTERS }}' )
       - name: Format tweet
         id: tweet
-        run: echo ::set-output name=formatted::$(bundle exec ruby lib/format_tweet.rb '${{ steps.uptake.outputs.world-fully }}')
+        run: echo ::set-output name=formatted::$(bundle exec ruby lib/format_tweet.rb '${{ steps.uptake.outputs.fully }}')
       - name: Fetch last tweet
         id: last-tweet
-        run: echo ::set-output name=text::$(bundle exec ruby lib/fetch_last_tweet.rb fullyjabbed)
+        run: echo ::set-output name=text::$(bundle exec ruby lib/fetch_last_tweet.rb ${{ env.TWITTER_SCREEN_NAME }})
         env:
              API_KEY: ${{ secrets.API_KEY }}
              API_KEY_SECRET: ${{ secrets.API_KEY_SECRET }}
@@ -47,7 +50,7 @@ jobs:
              ACCESS_TOKEN_SECRET: ${{ secrets.ACCESS_TOKEN_SECRET_WORLD }}
       - name: Debug output
         run: |
-          echo ${{ steps.uptake.outputs.second }}
+          echo ${{ steps.uptake.outputs.fully }}
           echo ${{ steps.tweet.outputs.formatted }}
           echo ${{ steps.last-tweet.outputs.text }}
       - name: Tweet current uptake


### PR DESCRIPTION
Some folks have asked for bots for other countries. I'd like it to be
easier to set up a new bot, for either me or a rando forking this.

So I've moved all the non-secrets that change between bots to
environment variables declared at the top of the job.

I've kept the twitter auth stuff where it is because I dont want secrets
passed to steps that dont need them.